### PR TITLE
[Fix] #23 테이블 뷰의 버튼이 작동하지 않았던 이슈 해결

### DIFF
--- a/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/TrainSearch/TrainInfoTableViewCell.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/TrainSearch/TrainInfoTableViewCell.swift
@@ -115,13 +115,16 @@ class TrainInfoTableViewCell: UITableViewCell {
         }
         
         func setHierachy() {
+            
             addSubviews(trainNameView, timeStackView, stroke, standardButton, premiumButton)
+            
             trainNameView.addSubview(trainNameLabel)
             timeStackView.addArrangedSubviews(
                 departureLabel,
                 arrowImageView,
                 arrivalLabel
             )
+            sendSubviewToBack(contentView)
         }
         
         


### PR DESCRIPTION
## 🌴 작업한 브랜치
- #23 


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
테이블 뷰의 버튼이 작동하지 않았던 이슈 해결
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

트러블슈팅페이지에 자세한 사항 적어두었습니다.
sendSubviewToBack(contentView) << 이걸로 해결함 !

``` swift
func setHierachy() {
            
            addSubviews(trainNameView, timeStackView, stroke, standardButton, premiumButton)
            
            trainNameView.addSubview(trainNameLabel)
            timeStackView.addArrangedSubviews(
                departureLabel,
                arrowImageView,
                arrivalLabel
            )
            sendSubviewToBack(contentView)
        }
```



## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #23 
