### PR TITLE
[Feat] #33 - 결제하기 뷰 결제 상세 및 하단 버튼 구현

### DIFF
--- a/KORAILTALK-iOS/KORAILTALK-iOS.xcodeproj/project.pbxproj
+++ b/KORAILTALK-iOS/KORAILTALK-iOS.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		D0E6BE722CEBA8D6006CDAA8 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = D0E6BE6E2CEBA8D6006CDAA8 /* Pretendard-Regular.otf */; };
 		D0E6BE742CEBAA2F006CDAA8 /* FontLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E6BE732CEBAA29006CDAA8 /* FontLiterals.swift */; };
 		D0E6BE762CEBB3F2006CDAA8 /* ColorLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E6BE752CEBB3EA006CDAA8 /* ColorLiterals.swift */; };
-		D0E6BE782CEBBAA1006CDAA8 /* UIString+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E6BE772CEBBA9B006CDAA8 /* UIString+.swift */; };
+		D0E6BE782CEBBAA1006CDAA8 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E6BE772CEBBA9B006CDAA8 /* String+.swift */; };
 		D0E937AC2CF76B420061782D /* BaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E937A72CF76B420061782D /* BaseService.swift */; };
 		D0E937AD2CF76B420061782D /* MoyaPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E937A82CF76B420061782D /* MoyaPlugin.swift */; };
 		D0E937AE2CF76B420061782D /* BaseTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E937A62CF76B420061782D /* BaseTargetType.swift */; };
@@ -143,7 +143,7 @@
 		D0E6BE6F2CEBA8D6006CDAA8 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		D0E6BE732CEBAA29006CDAA8 /* FontLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontLiterals.swift; sourceTree = "<group>"; };
 		D0E6BE752CEBB3EA006CDAA8 /* ColorLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorLiterals.swift; sourceTree = "<group>"; };
-		D0E6BE772CEBBA9B006CDAA8 /* UIString+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIString+.swift"; sourceTree = "<group>"; };
+		D0E6BE772CEBBA9B006CDAA8 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		D0E937A62CF76B420061782D /* BaseTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTargetType.swift; sourceTree = "<group>"; };
 		D0E937A72CF76B420061782D /* BaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseService.swift; sourceTree = "<group>"; };
 		D0E937A82CF76B420061782D /* MoyaPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaPlugin.swift; sourceTree = "<group>"; };
@@ -410,7 +410,7 @@
 				D03DF2222CEB844D00BE7CAE /* UIStackView+.swift */,
 				D03DF2262CEB859600BE7CAE /* UILabel+.swift */,
 				D03DF2282CEB863300BE7CAE /* UITextField+.swift */,
-				D0E6BE772CEBBA9B006CDAA8 /* UIString+.swift */,
+				D0E6BE772CEBBA9B006CDAA8 /* String+.swift */,
 				D03DF2242CEB845E00BE7CAE /* NSObject+.swift */,
 				D61E9A342CECDBAF0005D772 /* NSAttributedString+.swift */,
 				CB9473972CEC5F88002B4D25 /* UIImage+.swift */,
@@ -804,7 +804,7 @@
 				D0E6BE742CEBAA2F006CDAA8 /* FontLiterals.swift in Sources */,
 				D0F41C752CEF2A8000689EBC /* PaymentView.swift in Sources */,
 				D61E9E652CF5B5860005D772 /* OutletPopupViewController.swift in Sources */,
-				D0E6BE782CEBBAA1006CDAA8 /* UIString+.swift in Sources */,
+				D0E6BE782CEBBAA1006CDAA8 /* String+.swift in Sources */,
 				D61E9A352CECDBAF0005D772 /* NSAttributedString+.swift in Sources */,
 				D61E9E6E2CF710800005D772 /* TrainCheckViewController.swift in Sources */,
 				D022CDE22CF45E8E00A21713 /* VeteranDiscountViewController.swift in Sources */,

--- a/KORAILTALK-iOS/KORAILTALK-iOS.xcodeproj/project.pbxproj
+++ b/KORAILTALK-iOS/KORAILTALK-iOS.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		D07C21362CF595DF00C06522 /* CardPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07C21352CF595DA00C06522 /* CardPayView.swift */; };
 		D07C213A2CF5A5AD00C06522 /* SimplePayCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07C21392CF5A5AD00C06522 /* SimplePayCollectionViewCell.swift */; };
 		D07C213C2CF5ADFB00C06522 /* SimplePayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07C213B2CF5ADF600C06522 /* SimplePayModel.swift */; };
+		D0914AF92CF8F76500B3693B /* PaymentDetailSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0914AF82CF8F75C00B3693B /* PaymentDetailSectionView.swift */; };
 		D0E6BE702CEBA8D6006CDAA8 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = D0E6BE6D2CEBA8D6006CDAA8 /* Pretendard-Medium.otf */; };
 		D0E6BE712CEBA8D6006CDAA8 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = D0E6BE6F2CEBA8D6006CDAA8 /* Pretendard-SemiBold.otf */; };
 		D0E6BE722CEBA8D6006CDAA8 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = D0E6BE6E2CEBA8D6006CDAA8 /* Pretendard-Regular.otf */; };
@@ -136,6 +137,7 @@
 		D07C21352CF595DA00C06522 /* CardPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPayView.swift; sourceTree = "<group>"; };
 		D07C21392CF5A5AD00C06522 /* SimplePayCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePayCollectionViewCell.swift; sourceTree = "<group>"; };
 		D07C213B2CF5ADF600C06522 /* SimplePayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePayModel.swift; sourceTree = "<group>"; };
+		D0914AF82CF8F75C00B3693B /* PaymentDetailSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentDetailSectionView.swift; sourceTree = "<group>"; };
 		D0E6BE6D2CEBA8D6006CDAA8 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		D0E6BE6E2CEBA8D6006CDAA8 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		D0E6BE6F2CEBA8D6006CDAA8 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
@@ -512,6 +514,7 @@
 				D0F41C7E2CEF47D400689EBC /* DiscountSectionDetailView */,
 				D022CDD92CF458AC00A21713 /* ModalView */,
 				D07C212E2CF58FE800C06522 /* PaymentMethodSectionView.swift */,
+				D0914AF82CF8F75C00B3693B /* PaymentDetailSectionView.swift */,
 				D07C21302CF595AB00C06522 /* PaymentMethodSectionDetailView */,
 			);
 			path = SectionView;
@@ -736,6 +739,7 @@
 				D03DF2252CEB846500BE7CAE /* NSObject+.swift in Sources */,
 				D0E937BB2CF76F1F0061782D /* UserService.swift in Sources */,
 				D61E9A4D2CECFE380005D772 /* SeatsResponse.swift in Sources */,
+				D0914AF92CF8F76500B3693B /* PaymentDetailSectionView.swift in Sources */,
 				D07C21362CF595DF00C06522 /* CardPayView.swift in Sources */,
 				D07C21342CF595D600C06522 /* SimplePayView.swift in Sources */,
 				D03DF2212CEB844800BE7CAE /* UIView+.swift in Sources */,

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Global/Extensions/String+.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Global/Extensions/String+.swift
@@ -1,5 +1,5 @@
 //
-//  UIString+.swift
+//  String+.swift
 //  KORAILTALK-iOS
 //
 //  Created by 조혜린 on 11/19/24.

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Global/Extensions/UIView+.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Global/Extensions/UIView+.swift
@@ -47,4 +47,10 @@ extension UIView {
         layer.addSublayer(strokeLayer)
     }
     
+    func formatNumberWithComma(_ number: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        
+        return formatter.string(from: NSNumber(value: number)) ?? "\(number)"
+    }
 }

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/PaymentView.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/PaymentView.swift
@@ -19,9 +19,7 @@ final class PaymentView: UIView {
     private let ticketSectionView = TicketSectionView()
     let discountSectionView = DiscountSectionView()
     let paymentMethodSectionView = PaymentMethodSectionView()
-
-    //버튼 선택에 따라 contentView의 높이가 달라지기 때문에 임의로 bottom을 잡아주기 위해 추가
-    private let view = UIView()
+    let paymentDetailSectionView = PaymentDetailSectionView()
         
     // MARK: - Life Cycle
     
@@ -50,7 +48,7 @@ extension PaymentView {
         addSubview(scrollView)
         scrollView.addSubview(contentView)
         
-        contentView.addSubviews(ticketSectionView, discountSectionView, paymentMethodSectionView, view)
+        contentView.addSubviews(ticketSectionView, discountSectionView, paymentMethodSectionView, paymentDetailSectionView)
     }
     
     private func setLayout() {
@@ -79,9 +77,10 @@ extension PaymentView {
             $0.horizontalEdges.equalToSuperview()
         }
         
-        view.snp.makeConstraints {
+        paymentDetailSectionView.snp.makeConstraints {
             $0.top.equalTo(paymentMethodSectionView.snp.bottom).offset(8)
-            $0.bottom.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(5)
         }
     }
 }

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/PaymentView.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/PaymentView.swift
@@ -11,6 +11,10 @@ import SnapKit
 import Then
 
 final class PaymentView: UIView {
+    
+    //MARK: - Properties
+    
+    private let totalAmount = 12500
 
     //MARK: - UI Properties
     
@@ -143,5 +147,16 @@ extension PaymentView {
             $0.top.horizontalEdges.equalToSuperview().inset(10)
             $0.bottom.equalToSuperview().inset(42)
         }
+    }
+    
+    //MARK: - Func
+    
+    func updatePaymentInfo(discountAmount: Int) {
+        let totalString = "\(formatNumberWithComma(totalAmount - discountAmount))원"
+        let discountString = "\(formatNumberWithComma(discountAmount))원"
+        
+        totalPriceLabel.text = totalString
+        paymentDetailSectionView.totalPaymentAmountLabel.text = totalString
+        paymentDetailSectionView.discountAndPointLabel.text = discountString
     }
 }

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/PaymentView.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/PaymentView.swift
@@ -20,6 +20,11 @@ final class PaymentView: UIView {
     let discountSectionView = DiscountSectionView()
     let paymentMethodSectionView = PaymentMethodSectionView()
     let paymentDetailSectionView = PaymentDetailSectionView()
+    private let ticketPriceView = UIView()
+    private let totalQuantityLabel = UILabel()
+    private let totalPriceLabel = UILabel()
+    private let ticketingButton = UIButton()
+    private let buttonBackgroundView = UIView()
         
     // MARK: - Life Cycle
     
@@ -42,18 +47,48 @@ extension PaymentView {
     
     private func setStyle() {
         backgroundColor = .korailGrayscale(.gray100)
+        
+        ticketPriceView.do {
+            $0.backgroundColor = .korailTransparent(.blue95)
+        }
+        
+        totalQuantityLabel.do {
+            $0.text = "총 1매"
+            $0.font = .korailBody(.body2m14)
+            $0.textColor = .korailBasic(.white)
+        }
+        
+        totalPriceLabel.do {
+            $0.text = "12,500원"
+            $0.font = .korailHead(.head5m20)
+            $0.textColor = .korailBasic(.white)
+        }
+        
+        ticketingButton.do {
+            $0.setTitle("발권하기", for: .normal)
+            $0.setTitleColor(.korailBasic(.white), for: .normal)
+            $0.titleLabel?.font = .korailTitle(.title3m16)
+            $0.makeCornerRadius(cornerRadius: 25)
+            $0.backgroundColor = .korailGrayscale(.gray200)
+        }
+        
+        buttonBackgroundView.do {
+            $0.backgroundColor = .korailBasic(.white)
+        }
     }
     
     private func setHierarchy() {
-        addSubview(scrollView)
+        addSubviews(scrollView, ticketPriceView, buttonBackgroundView)
         scrollView.addSubview(contentView)
-        
+        ticketPriceView.addSubviews(totalQuantityLabel, totalPriceLabel)
+        buttonBackgroundView.addSubview(ticketingButton)
         contentView.addSubviews(ticketSectionView, discountSectionView, paymentMethodSectionView, paymentDetailSectionView)
     }
     
     private func setLayout() {
         scrollView.snp.makeConstraints{
-            $0.edges.equalTo(safeAreaLayoutGuide)
+            $0.top.horizontalEdges.equalTo(safeAreaLayoutGuide)
+            $0.bottom.equalTo(ticketPriceView.snp.top)
         }
         
         contentView.snp.makeConstraints {
@@ -81,6 +116,32 @@ extension PaymentView {
             $0.top.equalTo(paymentMethodSectionView.snp.bottom).offset(8)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview().inset(5)
+        }
+        
+        ticketPriceView.snp.makeConstraints {
+            $0.height.equalTo(56)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(buttonBackgroundView.snp.top)
+        }
+        
+        totalQuantityLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(16)
+        }
+        
+        totalPriceLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(16)
+        }
+        
+        buttonBackgroundView.snp.makeConstraints {
+            $0.height.equalTo(102)
+            $0.horizontalEdges.bottom.equalToSuperview()
+        }
+        
+        ticketingButton.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview().inset(10)
+            $0.bottom.equalToSuperview().inset(42)
         }
     }
 }

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/PaymentView.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/PaymentView.swift
@@ -27,7 +27,7 @@ final class PaymentView: UIView {
     private let ticketPriceView = UIView()
     private let totalQuantityLabel = UILabel()
     private let totalPriceLabel = UILabel()
-    private let ticketingButton = UIButton()
+    let ticketingButton = UIButton()
     private let buttonBackgroundView = UIView()
         
     // MARK: - Life Cycle

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/SectionView/ModalView/LPointModalView.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/SectionView/ModalView/LPointModalView.swift
@@ -37,7 +37,11 @@ final class LPointModalView: ModalBaseView {
     
     //MARK: - Properties
     
-    var pointAmouunt = "1483"
+    var pointAmount = "1000" {
+        didSet {
+            updatePointUI()
+        }
+    }
     
     //MARK: - UI Properties
     
@@ -116,7 +120,7 @@ extension LPointModalView {
             } else if textField == pointTextField {
                 textField.rightView = rightView
                 textField.rightViewMode = .always
-                textField.setPlaceholder(placeholder: pointAmouunt, fontColor: .korailGrayscale(.gray300), font: .korailBody(.body2m14))
+                textField.setPlaceholder(placeholder: pointAmount, fontColor: .korailGrayscale(.gray300), font: .korailBody(.body2m14))
                 textField.isEnabled = false
             }
         }
@@ -138,7 +142,7 @@ extension LPointModalView {
         }
         
         usablePointLabel.do {
-            $0.text = "사용 가능 포인트: \(pointAmouunt)점"
+            $0.text = "사용 가능 포인트: \(pointAmount)점"
             $0.font = .korailCaption(.caption2m12)
             $0.textColor = .korailGrayscale(.gray500)
             $0.textAlignment = .center
@@ -200,9 +204,16 @@ extension LPointModalView {
         }
     }
     
+    //MARK: - Private Func
+    
+    private func updatePointUI() {
+        usablePointLabel.text = "사용 가능 포인트: \(pointAmount)점"
+        pointTextField.setPlaceholder(placeholder: pointAmount, fontColor: .korailGrayscale(.gray300), font: .korailBody(.body2m14))
+    }
+    
     //MARK: - Func
     
     func applyAllAmount() {
-        pointTextField.text = pointAmouunt
+        pointTextField.text = String(pointAmount)
     }
 }

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/SectionView/PaymentDetailSectionView.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/SectionView/PaymentDetailSectionView.swift
@@ -1,0 +1,161 @@
+//
+//  PaymentDetailSectionView.swift
+//  KORAILTALK-iOS
+//
+//  Created by 조혜린 on 11/29/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class PaymentDetailSectionView: UIView {
+
+    //MARK: - UI Properties
+    
+    private let titleLabel = UILabel()
+    private let passengerLabel = UILabel()
+    private let usageAmountTextLabel = UILabel()
+    private let discountAndPointTextLabel = UILabel()
+    private let totalPaymentAmountTextLabel = UILabel()
+    private let usageAmountLabel = UILabel()
+    private let discountAndPointLabel = UILabel()
+    private let totalPaymentAmountLabel = UILabel()
+    private let titleStackView = UIStackView()
+    private let usageAmountStackView = UIStackView()
+    private let discountAndPointStackView = UIStackView()
+    private let totalPaymentAmountStackView = UIStackView()
+    private let deviderView = UIView()
+
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setStyle()
+        setHierarchy()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension PaymentDetailSectionView {
+    
+    // MARK: - Layout
+    
+    private func setStyle() {
+        backgroundColor = .korailBasic(.white)
+        
+        titleLabel.do {
+            $0.text = "결제수단 선택"
+            $0.textColor = .korailBasic(.black)
+            $0.textAlignment = .center
+            $0.font = .korailTitle(.title1sb18)
+        }
+        
+        passengerLabel.do {
+            $0.text = "어른 1명 -1매"
+            $0.textColor = .korailPurple(.purple02)
+            $0.textAlignment = .center
+            $0.font = .korailBody(.body2m14)
+        }
+        
+        usageAmountTextLabel.do {
+            $0.text = "이용금액"
+            $0.textColor = .korailBasic(.black)
+            $0.textAlignment = .center
+            $0.font = .korailBody(.body2m14)
+        }
+        
+        discountAndPointTextLabel.do {
+            $0.text = "할인 및 포인트"
+            $0.textColor = .korailBasic(.black)
+            $0.textAlignment = .center
+            $0.font = .korailBody(.body2m14)
+        }
+        
+        totalPaymentAmountTextLabel.do {
+            $0.text = "총 결제 금액"
+            $0.textColor = .korailBasic(.black)
+            $0.textAlignment = .center
+            $0.font = .korailTitle(.title3m16)
+        }
+        
+        usageAmountLabel.do {
+            $0.text = "12,500원"
+            $0.textColor = .korailBasic(.black)
+            $0.textAlignment = .center
+            $0.font = .korailTitle(.title3m16)
+        }
+        
+        discountAndPointLabel.do {
+            $0.text = "500원"
+            $0.textColor = .korailBasic(.black)
+            $0.textAlignment = .center
+            $0.font = .korailTitle(.title3m16)
+        }
+        
+        totalPaymentAmountLabel.do {
+            $0.text = "12,000원"
+            $0.textColor = .korailPurple(.purple04)
+            $0.textAlignment = .center
+            $0.font = .korailHead(.head5m20)
+        }
+        
+        [titleStackView, usageAmountStackView, discountAndPointStackView, totalPaymentAmountStackView].forEach { stackView in
+            stackView.axis = .horizontal
+            stackView.distribution = .equalSpacing
+            stackView.alignment = .center
+        }
+        
+        deviderView.do {
+            $0.backgroundColor = .korailGrayscale(.gray200)
+        }
+    }
+    
+    private func setHierarchy() {
+        addSubviews(titleStackView,
+                    usageAmountStackView,
+                    discountAndPointStackView,
+                    deviderView,
+                    totalPaymentAmountStackView)
+        titleStackView.addArrangedSubviews(titleLabel, passengerLabel)
+        usageAmountStackView.addArrangedSubviews(usageAmountTextLabel, usageAmountLabel)
+        discountAndPointStackView.addArrangedSubviews(discountAndPointTextLabel, discountAndPointLabel)
+        totalPaymentAmountStackView.addArrangedSubviews(totalPaymentAmountTextLabel, totalPaymentAmountLabel)
+
+    }
+    
+    private func setLayout() {
+        titleStackView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(20)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+        
+        usageAmountStackView.snp.makeConstraints {
+            $0.top.equalTo(titleStackView.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+        
+        discountAndPointStackView.snp.makeConstraints {
+            $0.top.equalTo(usageAmountStackView.snp.bottom).offset(8)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+        
+        deviderView.snp.makeConstraints {
+            $0.top.equalTo(discountAndPointStackView.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(1)
+        }
+        
+        totalPaymentAmountStackView.snp.makeConstraints {
+            $0.top.equalTo(deviderView.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().inset(16)
+        }
+    }
+}

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/SectionView/PaymentDetailSectionView.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/View/SectionView/PaymentDetailSectionView.swift
@@ -20,8 +20,8 @@ final class PaymentDetailSectionView: UIView {
     private let discountAndPointTextLabel = UILabel()
     private let totalPaymentAmountTextLabel = UILabel()
     private let usageAmountLabel = UILabel()
-    private let discountAndPointLabel = UILabel()
-    private let totalPaymentAmountLabel = UILabel()
+    let discountAndPointLabel = UILabel()
+    let totalPaymentAmountLabel = UILabel()
     private let titleStackView = UIStackView()
     private let usageAmountStackView = UIStackView()
     private let discountAndPointStackView = UIStackView()
@@ -93,7 +93,6 @@ extension PaymentDetailSectionView {
         }
         
         discountAndPointLabel.do {
-            $0.text = "500원"
             $0.textColor = .korailBasic(.black)
             $0.textAlignment = .center
             $0.font = .korailTitle(.title3m16)

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/ViewController/ModalViewController/LPointModalViewController.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/ViewController/ModalViewController/LPointModalViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol PointDelegate: AnyObject {
-    func applyPoint(pointText: String)
+    func applyPoint(pointAmount: Int)
 }
 
 final class LPointModalViewController: UIViewController {
@@ -19,7 +19,7 @@ final class LPointModalViewController: UIViewController {
     
     weak var delegate: PointDelegate?
     
-    var userPointInfo: LPointData?
+    var userLPointValue = 1000
     
     // MARK: - Life Cycle
     
@@ -32,15 +32,15 @@ final class LPointModalViewController: UIViewController {
         
         setAddTarget()
         
-        NetworkService.shared.userService.getUserLPoint(parameter: 123456) { [weak self] response in
-            guard let self else { return }
-            switch response {
-            case .success(let data):
-                userPointInfo = data?.data
-            default:
-                break
-            }
-        }
+//        NetworkService.shared.userService.getUserLPoint(parameter: 123456) { [weak self] response in
+//            guard let self else { return }
+//            switch response {
+//            case .success(let data):
+//                userLPointValue = data?.data.point
+//            default:
+//                break
+//            }
+//        }
     }
 }
 
@@ -86,7 +86,8 @@ extension LPointModalViewController {
     }
 
     @objc private func toolbarButtonTapped() {
-        delegate?.applyPoint(pointText: rootView.pointTextField.text ?? "")
+        let pointAmount = Int(rootView.pointTextField.text ?? "") ?? 0
+        delegate?.applyPoint(pointAmount: pointAmount)
         self.dismiss(animated: true)
     }
 }
@@ -110,8 +111,8 @@ extension LPointModalViewController: UITextFieldDelegate {
             }
         case rootView.pointTextField:
             if let inputNum = textField.text {
-                if Int(inputNum) ?? 0 >= Int(rootView.pointAmouunt) ?? 0 {
-                    textField.text = rootView.pointAmouunt
+                if Int(inputNum) ?? 0 >= userLPointValue {
+                    textField.text = String(userLPointValue)
                 } else if Int(inputNum) == 0 {
                     textField.text = "0"
                 } else if inputNum.first == "0" && inputNum.count > 1 {

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/ViewController/PaymentViewController.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/ViewController/PaymentViewController.swift
@@ -96,6 +96,11 @@ extension PaymentViewController {
         rootView.paymentMethodSectionView.simplePayDetailView.simplePayCollectionView.dataSource = self
     }
     
+    private func isPossibleTicketing(_ bool: Bool) {
+        rootView.ticketingButton.isEnabled = bool
+        rootView.ticketingButton.backgroundColor = bool ? .korailPurple(.purple03) : .korailGrayscale(.gray200)
+    }
+    
     //MARK: - @objc
     
     @objc private func discountSectionRadioButtonTapped(_ sender: UIButton) {
@@ -135,6 +140,7 @@ extension PaymentViewController {
     
     @objc private func paymentMethodSectionRadioButtonTapped(_ sender: UIButton) {
         rootView.paymentMethodSectionView.toggleDropDownState(sender: sender)
+        isPossibleTicketing(false)
     }
     
     @objc private func cardPayDetailViewDropDownButtonTapped(_ sender: UIButton) {
@@ -156,6 +162,7 @@ extension PaymentViewController {
     
     @objc private func cardPayDetailViewCheckBoxButtonTapped() {
         rootView.paymentMethodSectionView.cardPayDetailView.checkBoxButton.isSelected.toggle()
+        rootView.paymentMethodSectionView.cardPayDetailView.checkBoxButton.isSelected ? isPossibleTicketing(true) : isPossibleTicketing(false)
     }
 }
 
@@ -205,5 +212,6 @@ extension PaymentViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let cell = collectionView.cellForItem(at: indexPath)
         cell?.isSelected.toggle()
+        isPossibleTicketing(true)
     }
 }

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/ViewController/PaymentViewController.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Presentation/Payment/ViewController/PaymentViewController.swift
@@ -15,6 +15,12 @@ final class PaymentViewController: UIViewController {
     
     private let rootView = PaymentView()
     
+    private var discountAmount = 0 {
+        didSet {
+            rootView.updatePaymentInfo(discountAmount: discountAmount)
+        }
+    }
+    
     // MARK: - Life Cycle
     
     override func loadView() {
@@ -93,6 +99,7 @@ extension PaymentViewController {
     //MARK: - @objc
     
     @objc private func discountSectionRadioButtonTapped(_ sender: UIButton) {
+        discountAmount = 0
         rootView.discountSectionView.toggleDropDownState(sender: sender)
     }
     
@@ -101,6 +108,8 @@ extension PaymentViewController {
     }
     
     @objc private func toolbarButtonTapped() {
+        let discountAndPointText = rootView.discountSectionView.mileageDetailView.mileageTextField.text ?? ""
+        discountAmount = Int(discountAndPointText) ?? 0
         rootView.endEditing(true)
     }
     
@@ -153,12 +162,14 @@ extension PaymentViewController {
 extension PaymentViewController: DiscountDelegate {
     func applyDiscount() {
         rootView.discountSectionView.couponDetailView.applyVeteranDiscount(true)
+        discountAmount = 500
     }
 }
 
 extension PaymentViewController: PointDelegate {
-    func applyPoint(pointText: String) {
-        rootView.discountSectionView.pointDetailView.changeLPointButtonState(isApplied: true, pointText: pointText)
+    func applyPoint(pointAmount: Int) {
+        rootView.discountSectionView.pointDetailView.changeLPointButtonState(isApplied: true, pointText: String(pointAmount))
+        discountAmount = pointAmount
     }
 }
 


### PR DESCRIPTION
## 🌴 작업한 브랜치
- #33


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
결제하기 뷰의 결제 상세 섹션과 하단 버튼을 구현하였습니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|할인 적용|발권하기 활성화|
|:--:|:--:|
|<img src = "https://github.com/user-attachments/assets/117e3089-ad13-4084-9f21-8a32b7338704" width ="250">|<img src = "https://github.com/user-attachments/assets/0bf3e684-eb1e-46a8-a9b6-942761fed6ad" width ="250">|

## 📟 관련 이슈
- Resolved: #33
